### PR TITLE
Reallocation logic updated, cashrefund added

### DIFF
--- a/vhcb-bal/FinancialTransactions.cs
+++ b/vhcb-bal/FinancialTransactions.cs
@@ -392,7 +392,7 @@ namespace VHCBCommon.DataAccessLayer
         }
 
 
-        public static DataSet GetFinancialFundDetailsByProjectId(int projectId)
+        public static DataSet GetFinancialFundDetailsByProjectId(int projectId, bool isReallocation)
         {
             DataSet ds = new DataSet();
             var connection = new SqlConnection(ConfigurationManager.ConnectionStrings["dbConnection"].ConnectionString);
@@ -402,6 +402,7 @@ namespace VHCBCommon.DataAccessLayer
                 command.CommandType = CommandType.StoredProcedure;
                 command.CommandText = "GetFinancialFundDetailsByProjectId";
                 command.Parameters.Add(new SqlParameter("projectId", projectId));
+                command.Parameters.Add(new SqlParameter("isReallocation", isReallocation));
                 
                 using (connection)
                 {
@@ -1494,5 +1495,38 @@ namespace VHCBCommon.DataAccessLayer
             }
         }
 
+        public static DataTable GetBoardFinancialTrans()
+        {
+            DataTable dtBoardFinancialTrans = null;
+            var connection = new SqlConnection(ConfigurationManager.ConnectionStrings["dbConnection"].ConnectionString);
+            try
+            {
+                SqlCommand command = new SqlCommand();
+                command.CommandType = CommandType.StoredProcedure;
+                command.CommandText = "GetBoardFinancialTrans";
+                using (connection)
+                {
+                    connection.Open();
+                    command.Connection = connection;
+
+                    var ds = new DataSet();
+                    var da = new SqlDataAdapter(command);
+                    da.Fill(ds);
+                    if (ds.Tables.Count == 1 && ds.Tables[0].Rows != null)
+                    {
+                        dtBoardFinancialTrans = ds.Tables[0];
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+            finally
+            {
+                connection.Close();
+            }
+            return dtBoardFinancialTrans;
+        }
     }
 }

--- a/vhcbcloud/Commitments.aspx
+++ b/vhcbcloud/Commitments.aspx
@@ -14,6 +14,7 @@
                         <asp:ListItem Selected="true"> Commitment &nbsp;</asp:ListItem>
                         <asp:ListItem> DeCommitment &nbsp;</asp:ListItem>
                         <asp:ListItem> Reallocation &nbsp;</asp:ListItem>
+                        <asp:ListItem> Cash Refund &nbsp;</asp:ListItem>
                     </asp:RadioButtonList>
                 </div>
             </div>

--- a/vhcbcloud/Commitments.aspx.cs
+++ b/vhcbcloud/Commitments.aspx.cs
@@ -61,8 +61,10 @@ namespace vhcbcloud
                 Response.Redirect("Commitments.aspx");
             else if (rdBtnFinancial.SelectedIndex == 1)
                 Response.Redirect("Decommitments.aspx");
-            else
+            else if (rdBtnFinancial.SelectedIndex == 2)
                 Response.Redirect("Reallocations.aspx");
+            else
+                Response.Redirect("CashRefund.aspx");
         }
 
         protected void ddlProjFilter_SelectedIndexChanged(object sender, EventArgs e)

--- a/vhcbcloud/Decommitments.aspx
+++ b/vhcbcloud/Decommitments.aspx
@@ -14,6 +14,7 @@
                         <asp:ListItem> Commitment &nbsp;</asp:ListItem>
                         <asp:ListItem Selected="true"> DeCommitment &nbsp;</asp:ListItem>
                         <asp:ListItem> Reallocation &nbsp;</asp:ListItem>
+                         <asp:ListItem> Cash Refund &nbsp;</asp:ListItem>
                     </asp:RadioButtonList>
                 </div>
             </div>

--- a/vhcbcloud/Decommitments.aspx.cs
+++ b/vhcbcloud/Decommitments.aspx.cs
@@ -62,8 +62,10 @@ namespace vhcbcloud
                 Response.Redirect("Commitments.aspx");
             else if (rdBtnFinancial.SelectedIndex == 1)
                 Response.Redirect("Decommitments.aspx");
-            else
+            else if (rdBtnFinancial.SelectedIndex == 2)
                 Response.Redirect("Reallocations.aspx");
+            else
+                Response.Redirect("CashRefund.aspx");
         }
 
         protected void ddlProjFilter_SelectedIndexChanged(object sender, EventArgs e)

--- a/vhcbcloud/FinalizeTransactions.aspx
+++ b/vhcbcloud/FinalizeTransactions.aspx
@@ -26,28 +26,26 @@
                                 <td style="width: 20%; float: left"><span class="labelClass">Project # :</span></td>
                                 <td style="width: 20%; float: left">
                                     <asp:DropDownList ID="ddlProjFilter" CssClass="clsDropDown" AutoPostBack="true" runat="server" onclick="needToConfirm = false;"
-                                        OnSelectedIndexChanged="ddlProjFilter_SelectedIndexChanged" Height="16px" Width="111px">
+                                        OnSelectedIndexChanged="ddlProjFilter_SelectedIndexChanged" Width="111px">
                                     </asp:DropDownList></td>
                                 <td style="width: 10%; float: left">
                                     <asp:Label ID="lblProjNameText" class="labelClass" Visible="false" Text="Project Name :" runat="server"></asp:Label>
                                 </td>
-                                <td style="width: 15%; float: left">
+                                <td style="float: left" colspan="3">
                                     <asp:Label ID="lblProjName" class="labelClass" Text=" " runat="server"></asp:Label></td>
-                                <td style="width: 10%; float: left"></td>
-                                <td style="width: 20%; float: right"></td>
                             </tr>
                             <tr> <td colspan="6" style="height: 8px"></td>
                                 </tr>
                             <tr>
                                 <td style="width: 20%; float: left"><span class="labelClass">Board Financial Transactions :</span></td>
                                 <td style="width: 20%; float: left" colspan="5">
-                                    <asp:DropDownList ID="ddlFinancialTrans" CssClass="clsDropDown" runat="server" Height="16px" Width="161px">
-                                        <asp:ListItem Text="Select Financial Transaction" Value="0"></asp:ListItem>
+                                    <asp:DropDownList ID="ddlFinancialTrans" CssClass="clsDropDown" runat="server" Width="161px">
+                                      <%--  <asp:ListItem Text="Select Financial Transaction" Value="0"></asp:ListItem>
                                         <asp:ListItem Text="All" Value="-1"></asp:ListItem>
                                         <asp:ListItem Text="Commitments" Value="238"></asp:ListItem>
                                         <asp:ListItem Text="DeCommitments" Value="239"></asp:ListItem>
                                         <asp:ListItem Text="Board Reallocation" Value="240"></asp:ListItem>
-                                        <asp:ListItem Text="Cash Refund" Value="237"></asp:ListItem>
+                                        <asp:ListItem Text="Cash Refund" Value="237"></asp:ListItem>--%>
                                     </asp:DropDownList>
                                 </td>
                             </tr>

--- a/vhcbcloud/FinalizeTransactions.aspx.cs
+++ b/vhcbcloud/FinalizeTransactions.aspx.cs
@@ -33,6 +33,13 @@ namespace vhcbcloud
                 ddlProjFilter.DataBind();
                 ddlProjFilter.Items.Insert(0, new ListItem("Select", "NA"));
                 ddlProjFilter.Items.Insert(1, new ListItem("All", "-1"));
+
+                ddlFinancialTrans.DataSource = FinancialTransactions.GetBoardFinancialTrans();
+                ddlFinancialTrans.DataValueField = "TypeID";
+                ddlFinancialTrans.DataTextField = "Description";
+                ddlFinancialTrans.DataBind();
+                ddlFinancialTrans.Items.Insert(0, new ListItem("Select Financial Transaction", "0"));
+                ddlFinancialTrans.Items.Insert(1, new ListItem("All", "-1"));
             }
             catch (Exception ex)
             {
@@ -215,7 +222,7 @@ namespace vhcbcloud
                 }
             }
 
-            PopulateTransactions(Convert.ToInt32(ddlProjFilter.SelectedValue.ToString()), DateTime.Parse(ViewState["FromDate"].ToString()), DateTime.Parse(ViewState["EndDate"].ToString()), 
+            PopulateTransactions(Convert.ToInt32(ddlProjFilter.SelectedValue.ToString()), DateTime.Parse(ViewState["FromDate"].ToString()), DateTime.Parse(ViewState["EndDate"].ToString()),
                 Convert.ToInt32(ddlFinancialTrans.SelectedValue.ToString()));
         }
     }

--- a/vhcbcloud/Reallocations.aspx
+++ b/vhcbcloud/Reallocations.aspx
@@ -15,6 +15,7 @@
                         <asp:ListItem> Commitment &nbsp;</asp:ListItem>
                         <asp:ListItem> DeCommitment &nbsp;</asp:ListItem>
                         <asp:ListItem Selected="true"> Reallocation &nbsp;</asp:ListItem>
+                        <asp:ListItem> Cash Refund &nbsp;</asp:ListItem>
                     </asp:RadioButtonList>
                 </div>
             </div>

--- a/vhcbcloud/Reallocations.aspx.cs
+++ b/vhcbcloud/Reallocations.aspx.cs
@@ -26,8 +26,10 @@ namespace vhcbcloud
                 Response.Redirect("Commitments.aspx");
             else if (rdBtnFinancial.SelectedIndex == 1)
                 Response.Redirect("Decommitments.aspx");
-            else
+            else if (rdBtnFinancial.SelectedIndex == 2)
                 Response.Redirect("Reallocations.aspx");
+            else
+                Response.Redirect("CashRefund.aspx");
         }
 
         protected void BindProjects()
@@ -318,7 +320,7 @@ namespace vhcbcloud
         {
             if (ddlRFromProj.SelectedIndex > 0)
             {
-                string url = "/awardsummary.aspx?projectid=" + ddlRFromProj.SelectedValue.ToString();
+                string url = "/awardsummary.aspx?projectid=" + ddlRFromProj.SelectedValue.ToString() + "&Reallocations=true";
                 StringBuilder sb = new StringBuilder();
                 sb.Append("<script type = 'text/javascript'>");
                 sb.Append("window.open('");

--- a/vhcbcloud/awardsummary.aspx
+++ b/vhcbcloud/awardsummary.aspx
@@ -16,6 +16,7 @@
                     </p>
                     <asp:Panel runat="server" ID="Panel1" Width="100%" Height="200px" ScrollBars="Vertical">
                         <asp:GridView ID="gvCurrentAwdStatus" runat="server" AutoGenerateColumns="False" CssClass="gridView" EnableTheming="True" GridLines="None"
+                             OnRowCreated="gvCurrentAwdStatus_RowCreated"
                             ShowFooter="True" Width="90%">
                             <AlternatingRowStyle CssClass="alternativeRowStyle" />
                             <PagerStyle CssClass="pagerStyle" ForeColor="#F78B0E" />
@@ -23,6 +24,16 @@
                             <RowStyle CssClass="rowStyle" />
                             <FooterStyle CssClass="footerStyleTotals" />
                             <Columns>
+                                
+                                 <asp:TemplateField HeaderText="Reallocate To">
+                                    <ItemTemplate>
+                                        <asp:Label ID="lblReallocateTo" runat="Server" Text='<%# Eval("ProjectName") %>' />
+                                    </ItemTemplate>
+                                    <FooterTemplate>
+                                        Totals :
+                                    </FooterTemplate>
+                                </asp:TemplateField>
+
                                 <asp:TemplateField ItemStyle-HorizontalAlign="Center" Visible="false" HeaderText="Select">
                                     <ItemTemplate>
                                         <asp:HiddenField ID="HiddenField1" runat="server" Value='<%#Eval("fundid")%>' />
@@ -33,9 +44,6 @@
                                     <ItemTemplate>
                                         <asp:Label ID="lblFundName" runat="Server" Text='<%# Eval("FundName") %>' />
                                     </ItemTemplate>
-                                    <FooterTemplate>
-                                        Totals :
-                                    </FooterTemplate>
                                 </asp:TemplateField>
                                 <asp:TemplateField HeaderText="Grant/Loan/Contract" SortExpression="FundType">
                                     <ItemTemplate>

--- a/vhcbcloud/awardsummary.aspx.cs
+++ b/vhcbcloud/awardsummary.aspx.cs
@@ -11,17 +11,23 @@ namespace vhcbcloud
 {
     public partial class awardsummary : System.Web.UI.Page
     {
+        bool isReallocation = false;
+
         protected void Page_Load(object sender, EventArgs e)
         {
+            string reallocarionFlag = Request.QueryString["Reallocations"];
+            isReallocation = reallocarionFlag == "true";
+
             if (!IsPostBack)
             {
                 string projId = Request.QueryString["projectid"];
+
                 DataTable dtProjects = GetProjects();
                 BindProjects(dtProjects);
 
                 if (projId != null)
                 {
-                    lblProjId.Text = GetProjectName(dtProjects, projId) + " - " + projId;
+                    lblProjId.Text = GetProjectName(dtProjects, projId);
                     ddlProj.Items.FindByValue(projId).Selected = true;
                     BindAwardSummary(Convert.ToInt32(projId));
                 }
@@ -55,8 +61,9 @@ namespace vhcbcloud
             try
             {
                 lblErrorMsg.Text = ""; DataTable dtAwdStatus = null; DataTable dtTransDetail = null;
-                dtAwdStatus = FinancialTransactions.GetFinancialFundDetailsByProjectId(projectid).Tables[0];
-                dtTransDetail = FinancialTransactions.GetFinancialFundDetailsByProjectId(projectid).Tables[1];
+                dtAwdStatus = FinancialTransactions.GetFinancialFundDetailsByProjectId(projectid, isReallocation).Tables[0];
+                dtTransDetail = FinancialTransactions.GetFinancialFundDetailsByProjectId(projectid, isReallocation).Tables[1];
+
                 gvCurrentAwdStatus.DataSource = dtAwdStatus;
                 gvCurrentAwdStatus.DataBind();
 
@@ -106,12 +113,24 @@ namespace vhcbcloud
             }
         }
 
+        protected void gvCurrentAwdStatus_RowCreated(object sender, GridViewRowEventArgs e)
+        {
+            e.Row.Cells[0].Visible = isReallocation;
+
+            if (!isReallocation && e.Row.RowType == DataControlRowType.Footer)
+            {
+                Label l = new Label();
+                l.Text = "Totals :";
+                e.Row.Cells[2].Controls.Add(l);
+            }
+        }
+
         protected void ddlProj_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (ddlProj.SelectedIndex > 0)
             {
                 DataTable dtProjects = GetProjects();
-                lblProjId.Text = GetProjectName(dtProjects, ddlProj.SelectedValue.ToString()) + " - " + ddlProj.SelectedValue.ToString();
+                lblProjId.Text = GetProjectName(dtProjects, ddlProj.SelectedValue.ToString());// +" - " + ddlProj.SelectedValue.ToString();
                 BindAwardSummary(Convert.ToInt32(ddlProj.SelectedValue.ToString()));
             }
         }


### PR DESCRIPTION
Added "All" feature in Projects and Commitment Type Drop Downs.
Populating Transactions and details with Project Name, Project Number and Commitment Type.
Displaying Project Name, Project Number and Commitment Type in Data Grid View.

Created a new screen for Cash Review.
"Finalize Transactions"
"Board Financial Transactions" data populating from Database, created a proc "GetBoardFinancialTrans".
Grid sorted with Project Number
Re-searching and understanding the Award Summary logic
"Award Summary" 
Fixed the HOPWA issue by altered the proc [dbo].[GetFinancialFundDetailsByProjectId] and created a new view "LkTransType_v".
Removed the project id from Header.
Currently it is breaking when "pendingamount=""" fixed this issue(input string not in a format error) by altering the proc "GetFinancialFundDetailsByProjectId".
Passing "Reallocations=true" query string parameter when the user is coming from the "Reallocation" page.
Enable and Disable the "Reallocate To" column based on "Reallocations" flag.
When "Reallocate To" column is disable show "Totals : " text under "Fund" column.
Fixed the grid data by altering the procs "GetFinancialFundDetailsByProjectId" and "GetReallocationFinancialFundDetailsByProjectId" now the logic for fetching Reallocation data is different from others(commit/decommit/cashRefund).
"Cash Refund" radio button functionality added in Commitment, De-Commitment and Reallocation pages. 
