### PR TITLE
Bugs Fixed

### DIFF
--- a/vhcbcloud/ProjectMaintenance.aspx.cs
+++ b/vhcbcloud/ProjectMaintenance.aspx.cs
@@ -379,6 +379,7 @@ namespace vhcbcloud
             PopulateDropDown(ddlProjectType, drProjectDetails["LkProjectType"].ToString());
 
             txtProjectName.Text = drProjectDetails["projectName"].ToString();
+            txtProjectName.Enabled = false;
             txtClosingDate.Text = drProjectDetails["ClosingDate"].ToString() == "" ? "" : Convert.ToDateTime(drProjectDetails["ClosingDate"].ToString()).ToShortDateString();
             cbVerified.Checked = DataUtils.GetBool(drProjectDetails["verified"].ToString());
 
@@ -475,6 +476,7 @@ namespace vhcbcloud
                 txtProjNum.Visible = true;
                 ddlProject.Visible = false;
                 ddlProgram.Enabled = true;
+                txtProjectName.Enabled = true;
                 btnProjectUpdate.Visible = false;
                 dvSubmit.Visible = true;
                 cbActiveOnly.Visible = false;
@@ -561,6 +563,8 @@ namespace vhcbcloud
                         DataUtils.GetInt(ddlProgram.SelectedValue.ToString()), DataUtils.GetInt(ddlManager.SelectedValue.ToString()), 
                         txtClosingDate.Text, cbVerified.Checked, DataUtils.GetInt(ddlPrimaryApplicant.SelectedValue.ToString()), 
                         txtProjectName.Text);
+
+                    this.BindProjectEntityGrid();
 
                     LogMessage("Project updated successfully");
 

--- a/vhcbcloud/ProjectSearch.aspx.cs
+++ b/vhcbcloud/ProjectSearch.aspx.cs
@@ -228,6 +228,7 @@ namespace vhcbcloud
 
         protected void btnProjectClear_Click(object sender, EventArgs e)
         {
+            dvSearchResults.Visible = false;
             txtProjNum.Text = "";
             txtProjectName.Text = "";
             ddlPrimaryApplicant.SelectedIndex = -1;

--- a/vhcbcloud/SQL/EntityMaintenance.sql
+++ b/vhcbcloud/SQL/EntityMaintenance.sql
@@ -197,7 +197,7 @@ begin transaction
 			HomePhone = @HomePhone, CellPhone = @CellPhone, WorkPhone = @WorkPhone, email = @Email
 		from applicant where  ApplicantId = @ApplicantId
 
-		update an set an.Applicantname = @ApplicantName
+		update an set an.Applicantname =  @lname +', '+ @fname
 		from applicant a(nolock) 
 		join applicantappname aan(nolock) on aan.ApplicantID = a.ApplicantId
 		join appname an(nolock) on aan.AppNameID = an.AppNameID

--- a/vhcbcloud/SQL/ProjectManagement.sql
+++ b/vhcbcloud/SQL/ProjectManagement.sql
@@ -203,6 +203,10 @@ begin transaction
 		from ProjectApplicant pa
 		where projectId = @projectId and pa.LkApplicantRole = 358
 
+		--Delete If the Entity/Applicant already assigned some time back.
+		delete from ProjectApplicant 
+		where ProjectId = @ProjectId and ApplicantId = @applicantId
+
 		--Insert New Primary Applicant
 		insert into ProjectApplicant (ProjectId, ApplicantId, LkApplicantRole, IsApplicant)
 		values (@ProjectId, @applicantId, 358, 1)


### PR DESCRIPTION
1.       Project Search page – Click on clear button – should also clear the grid of records from a prior search -- Fix In Code
2.       Edit Individual on Entity maintenance page not working, it gets rid of the record (makes it a blank record) and changes around first/last name -- DB Change "UpdateEntity"
3.       Change primary applicant in project page – does not update entity grid with this info and does not update the projectapplicant with this info since it reverts back to the old primary applicant
Entity grid not refreshing -- Fix in Code
4.       If primary applicant is modified and then down the road the previous primary applicant becomes the current primary applicant, don’t add the applicant again, use the existing record and change type back to primary applicant 
        – duplicating entry DB Change "UpdateProjectInfo"
5.       Do not allow edit of project name in Project Maintenance since it ignores it – disable field --  Fix In Code