### PR TITLE
Fixed Entity Role dependecy on Database value

### DIFF
--- a/vhcb-bal/EntityMaintenanceData.cs
+++ b/vhcb-bal/EntityMaintenanceData.cs
@@ -14,7 +14,8 @@ namespace VHCBCommon.DataAccessLayer
 
         public static EntityMaintResult AddNewEntity(int LkEntityType, int LKEntityType2, string FYend, string Website, string Email, string HomePhone, string WorkPhone, string CellPhone, string Stvendid,
             string ApplicantName, string Fname, string Lname, int Position, string Title, string FarmName, int LkFVEnterpriseType, int AcresInProduction,
-            int AcresOwned, int AcresLeased, int AcresLeasedOut, int TotalAcres, bool OutOFBiz, string Notes, string AgEd, int YearsManagingFarm, int? AppRole)
+            int AcresOwned, int AcresLeased, int AcresLeasedOut, int TotalAcres, bool OutOFBiz, string Notes, string AgEd, int YearsManagingFarm, int? AppRole,
+            int Operation)
         {
             try
             {
@@ -54,7 +55,8 @@ namespace VHCBCommon.DataAccessLayer
                         command.Parameters.Add(new SqlParameter("AgEd", AgEd));
                         command.Parameters.Add(new SqlParameter("YearsManagingFarm", YearsManagingFarm));
                         command.Parameters.Add(new SqlParameter("AppRole", AppRole));
-
+                        command.Parameters.Add(new SqlParameter("Operation", Operation));
+                        
                         SqlParameter parmMessage = new SqlParameter("@isDuplicate", SqlDbType.Bit);
                         parmMessage.Direction = ParameterDirection.Output;
                         command.Parameters.Add(parmMessage);
@@ -84,7 +86,8 @@ namespace VHCBCommon.DataAccessLayer
 
         public static void UpdateEntity(int ApplicantId, int LkEntityType, int LKEntityType2, string FYend, string Website, string Email, string HomePhone, string WorkPhone, string CellPhone, string Stvendid,
             string ApplicantName, string Fname, string Lname, int Position, string Title, string FarmName, int LkFVEnterpriseType, int AcresInProduction,
-            int AcresOwned, int AcresLeased, int AcresLeasedOut, int TotalAcres, bool OutOFBiz, string Notes, string AgEd, int YearsManagingFarm, int AppRole)
+            int AcresOwned, int AcresLeased, int AcresLeasedOut, int TotalAcres, bool OutOFBiz, string Notes, string AgEd, int YearsManagingFarm, int AppRole, 
+            int Operation)
         {
             try
             {
@@ -125,6 +128,7 @@ namespace VHCBCommon.DataAccessLayer
                         command.Parameters.Add(new SqlParameter("AgEd", AgEd));
                         command.Parameters.Add(new SqlParameter("YearsManagingFarm", YearsManagingFarm));
                         command.Parameters.Add(new SqlParameter("AppRole", AppRole));
+                        command.Parameters.Add(new SqlParameter("Operation", Operation));
 
                         command.CommandTimeout = 60 * 5;
 
@@ -171,7 +175,7 @@ namespace VHCBCommon.DataAccessLayer
             return dt;
         }
 
-        public static DataTable GetEntitiesByRole(int LKEntityType2)
+        public static DataTable GetEntitiesByRole(int LKEntityType2, int Operation)
         {
             DataTable dtProjects = null;
             var connection = new SqlConnection(ConfigurationManager.ConnectionStrings["dbConnection"].ConnectionString);
@@ -181,6 +185,8 @@ namespace VHCBCommon.DataAccessLayer
                 command.CommandType = CommandType.StoredProcedure;
                 command.CommandText = "GetEntitiesByRole";
                 command.Parameters.Add(new SqlParameter("LKEntityType2", LKEntityType2));
+                command.Parameters.Add(new SqlParameter("Operation", Operation));
+
                 using (connection)
                 {
                     connection.Open();

--- a/vhcbcloud/EntityMaintenance.aspx.cs
+++ b/vhcbcloud/EntityMaintenance.aspx.cs
@@ -35,7 +35,7 @@ namespace vhcbcloud
                     string SelectedRole = ddlEntityRole.SelectedValue.ToString();
 
                     dvExistingEntities.Visible = true;
-                    BindApplicants(DataUtils.GetInt(SelectedRole), ddlEntityName);
+                    BindApplicants(DataUtils.GetInt(SelectedRole), ddlEntityRole.SelectedItem.ToString(), ddlEntityName);
                 }
                 else
                 {
@@ -172,12 +172,21 @@ namespace vhcbcloud
                 lblErrorMsg.Text = ex.Message;
             }
         }
-        protected void BindApplicants(int RoleId, DropDownList ddList)
+        protected void BindApplicants(int RoleId, string RoleName, DropDownList ddList)
         {
             try
             {
-                ddList.Items.Clear();
-                ddList.DataSource = EntityMaintenanceData.GetEntitiesByRole(RoleId);
+                int Operation = 0;
+
+                if (RoleName.ToLower() == "individual")
+                    Operation = 1;
+                else if (RoleName.ToLower() == "organization")
+                    Operation = 2;
+                else if (RoleName.ToLower() == "farm")
+                    Operation = 3;
+
+                    ddList.Items.Clear();
+                ddList.DataSource = EntityMaintenanceData.GetEntitiesByRole(RoleId, Operation);
                 ddList.DataValueField = "ApplicantId";
                 ddList.DataTextField = "Applicantname";
                 ddList.DataBind();
@@ -441,7 +450,7 @@ namespace vhcbcloud
                             txtEmail.Text, HomePhoneNumber, WorkPhoneNumber, CellPhoneNumber, txtStateVendorId.Text, txtApplicantName.Text, txtFirstName.Text, txtLastName.Text, DataUtils.GetInt(ddlPosition.SelectedValue.ToString()),
                             txtTitle.Text, null, 0, 0, 0,
                             0, 0, 0, false, null, null,
-                            0, null);
+                            0, null, 1); //1=Individual
 
                         if (objEntityMaintResult.IsDuplicate)
                         {
@@ -461,7 +470,7 @@ namespace vhcbcloud
                            null, HomePhoneNumber, WorkPhoneNumber, CellPhoneNumber, txtStateVendorId.Text, txtApplicantName.Text, null, null, 0,
                            null, null, 0, 0, 0,
                            0, 0, 0, false, null, null,
-                           0, DataUtils.GetInt(ddlDefaultRole.SelectedValue.ToString()));
+                           0, DataUtils.GetInt(ddlDefaultRole.SelectedValue.ToString()), 2); //2=Organization
                         ClearForm();
                         PopulateEntity(objEntityMaintResult.ApplicantId, DataUtils.GetInt(ddlEntityRole.SelectedValue.ToString()));
                         LogMessage("New Entity Added Successfully");
@@ -472,7 +481,7 @@ namespace vhcbcloud
                            null, HomePhoneNumber, WorkPhoneNumber, CellPhoneNumber, txtStateVendorId.Text, txtApplicantName.Text, null, null, 0,
                            null, txtFarmName.Text, DataUtils.GetInt(ddlFarmType.SelectedValue.ToString()), DataUtils.GetInt(txtAcresInProduction.Text), DataUtils.GetInt(txtAcresOwned.Text),
                            DataUtils.GetInt(txtAcresLeased.Text), DataUtils.GetInt(txtAcresLeasedOut.Text), DataUtils.GetInt(txtTotalAcres.Text), cbIsNoLongerBusiness.Checked, txtNotes.Text, txtAgrEdu.Text,
-                           DataUtils.GetInt(txtYearsManagingForm.Text), DataUtils.GetInt(ddlDefaultRole.SelectedValue.ToString()));
+                           DataUtils.GetInt(txtYearsManagingForm.Text), DataUtils.GetInt(ddlDefaultRole.SelectedValue.ToString()), 3); //3=Farm
                         ClearForm();
                         PopulateEntity(objEntityMaintResult.ApplicantId, DataUtils.GetInt(ddlEntityRole.SelectedValue.ToString()));
                         LogMessage("New Entity Added Successfully");
@@ -480,6 +489,15 @@ namespace vhcbcloud
                 }
                 else
                 {
+                    int Operation = 0;
+
+                    if (ddlEntityRole.SelectedItem.Text.ToLower() == "individual")
+                        Operation = 1;
+                    else if(ddlEntityRole.SelectedItem.Text.ToLower() == "organization")
+                        Operation = 2;
+                    else if(ddlEntityRole.SelectedItem.Text.ToLower() == "farm")
+                        Operation = 3;
+
                     string HomePhoneNumber = new string(txtHomePhone.Text.Where(c => char.IsDigit(c)).ToArray());
                     string WorkPhoneNumber = new string(txtWorkPhone.Text.Where(c => char.IsDigit(c)).ToArray());
                     string CellPhoneNumber = new string(txtCellPhone.Text.Where(c => char.IsDigit(c)).ToArray());
@@ -488,7 +506,7 @@ namespace vhcbcloud
                            txtEmail.Text, HomePhoneNumber, WorkPhoneNumber, CellPhoneNumber, txtStateVendorId.Text, txtApplicantName.Text, txtFirstName.Text, txtLastName.Text, DataUtils.GetInt(ddlPosition.SelectedValue.ToString()),
                            txtTitle.Text, txtFarmName.Text, DataUtils.GetInt(ddlFarmType.SelectedValue.ToString()), DataUtils.GetInt(txtAcresInProduction.Text), DataUtils.GetInt(txtAcresOwned.Text),
                            DataUtils.GetInt(txtAcresLeased.Text), DataUtils.GetInt(txtAcresLeasedOut.Text), DataUtils.GetInt(txtTotalAcres.Text), cbIsNoLongerBusiness.Checked, txtNotes.Text, txtAgrEdu.Text,
-                           DataUtils.GetInt(txtYearsManagingForm.Text), DataUtils.GetInt(ddlDefaultRole.SelectedValue.ToString()));
+                           DataUtils.GetInt(txtYearsManagingForm.Text), DataUtils.GetInt(ddlDefaultRole.SelectedValue.ToString()), Operation);
                     ClearForm();
                     PopulateEntity(DataUtils.GetInt(ddlEntityName.SelectedValue.ToString()), DataUtils.GetInt(ddlEntityRole.SelectedValue.ToString()));
                     LogMessage("Entity Updated Successfully");
@@ -504,7 +522,7 @@ namespace vhcbcloud
 
             PopulateDropDown(ddlEntityRole, EntityRole.ToString());
 
-            BindApplicants(DataUtils.GetInt(ddlEntityRole.SelectedValue.ToString()), ddlEntityName);
+            BindApplicants(DataUtils.GetInt(ddlEntityRole.SelectedValue.ToString()), ddlEntityRole.SelectedItem.ToString(), ddlEntityName);
             PopulateDropDown(ddlEntityName, ApplicantId.ToString());
             EntityNameChanged();
         }
@@ -537,14 +555,14 @@ namespace vhcbcloud
                         dvNewAttribute.Visible = true;
                         dvNewProduct.Visible = true;
                         dvAttachEntities.Visible = true;
-                        BindApplicants(26243, ddlIndividualApplicant);
+                        BindApplicants(DataUtils.GetInt(ddlEntityRole.SelectedItem.Value), ddlEntityRole.SelectedItem.ToString(), ddlIndividualApplicant);
                     }
                     else
                     {
                         if (ddlEntityRole.SelectedItem.ToString().ToLower() == "organization")
                         {
                             dvAttachEntities.Visible = true;
-                            BindApplicants(26243, ddlIndividualApplicant);
+                            BindApplicants(DataUtils.GetInt(ddlEntityRole.SelectedItem.Value), ddlEntityRole.SelectedItem.ToString(), ddlIndividualApplicant);
                         }
                         else
                         {

--- a/vhcbcloud/SQL/EntityMaintenance.sql
+++ b/vhcbcloud/SQL/EntityMaintenance.sql
@@ -36,6 +36,7 @@ create procedure dbo.AddNewEntity
 	@AgEd				nvarchar(max) = null,
 	@YearsManagingFarm	int = null,
 	@AppRole			int = null,
+	@Operation			int = null,
 	@isDuplicate		bit output,
 	@ApplicantId		int output
 ) as
@@ -49,7 +50,7 @@ begin transaction
 
 	set @isDuplicate = 0
 
-	if (@LKEntityType2 = 26243)--Individual
+	if (@Operation = 1)--Individual
 	begin
 
 	set @isDuplicate = 1
@@ -88,7 +89,7 @@ begin transaction
 		end
 
 	end
-	else if (@LKEntityType2 = 26242)--Organization
+	else if (@Operation = 2)--Organization
 	begin
 		insert into applicant(LkEntityType, LKEntityType2, Individual, FYend, website, email, HomePhone, WorkPhone, CellPhone, Stvendid, AppRole)
 		values(@LkEntityType, @LKEntityType2, 1, @FYend, @Website, @Email, @HomePhone, @WorkPhone, @CellPhone, @Stvendid, @AppRole)
@@ -104,7 +105,7 @@ begin transaction
 
 		set @isDuplicate = 0
 	end
-	else if (@LKEntityType2 = 26244)--Farm
+	else if (@Operation = 3)--Farm
 	begin
 		insert into applicant(LkEntityType, LKEntityType2, Individual, FYend, website, email, HomePhone, WorkPhone, CellPhone, Stvendid, AppRole)
 		values(@LkEntityType, @LKEntityType2, 1, @FYend, @Website, @Email, @HomePhone, @WorkPhone, @CellPhone, @Stvendid, @AppRole)
@@ -175,7 +176,8 @@ create procedure dbo.UpdateEntity
 	@Notes				nvarchar(max) = null,
 	@AgEd				nvarchar(max) = null,
 	@YearsManagingFarm	int = null,
-	@AppRole			int = null
+	@AppRole			int = null,
+	@Operation			int = null
 ) as
 begin transaction
 
@@ -186,7 +188,7 @@ begin transaction
 	declare @AddressId int;
 
 
-	if (@LKEntityType2 = 26243)--Individual
+	if (@Operation = 1)--Individual
 	begin
 
 		update c set Firstname = @Fname, Lastname = @Lname, LkPosition =@Position, Title = @Title
@@ -206,7 +208,7 @@ begin transaction
 		where a.ApplicantId = @ApplicantId
 
 	end
-	else if (@LKEntityType2 = 26242)--Organization
+	else if (@Operation = 2)--Organization
 	begin
 		update applicant 
 		set LkEntityType = @LkEntityType, FYend = @FYend, website = @Website, Stvendid = @Stvendid, 
@@ -220,7 +222,7 @@ begin transaction
 		join appname an(nolock) on aan.AppNameID = an.AppNameID
 		where a.ApplicantId = @ApplicantId
 	end
-	else if (@LKEntityType2 = 26244)--Farm
+	else if (@Operation = 3)--Farm
 	begin
 		update applicant 
 		set LkEntityType = @LkEntityType, FYend = @FYend, website = @Website, Stvendid = @Stvendid, 
@@ -276,8 +278,8 @@ begin
 	select a.LkEntityType, a.LKEntityType2, a.Individual, a.FYend, a.website, a.email, a.HomePhone, a.WorkPhone, a.CellPhone, a.Stvendid, a.AppRole,
 		c.Firstname, c.Lastname, c.LkPosition, c.Title,
 		an.Applicantname,
-		f.ApplicantID, f.FarmId, f.FarmName, f.LkFVEnterpriseType, f.AcresInProduction, f.AcresOwned, f.AcresLeased, f.AcresLeasedOut, f.TotalAcres, f.OutOFBiz, 
-			f.Notes, f.AgEd, f.YearsManagingFarm
+		f.ApplicantID, f.FarmId, f.FarmName, f.LkFVEnterpriseType, f.AcresInProduction, f.AcresOwned, f.AcresLeased, f.AcresLeasedOut, f.TotalAcres, 
+		f.OutOFBiz, f.Notes, f.AgEd, f.YearsManagingFarm
 	from applicant a(nolock) 
 	left join applicantcontact ac(nolock) on ac.ApplicantID = a.ApplicantID
 	left join contact c(nolock) on c.ContactId = ac.ContactID
@@ -295,12 +297,13 @@ go
 
 create procedure dbo.GetEntitiesByRole
 (
-	@LKEntityType2	int
+	@LKEntityType2	int,
+	@Operation		int
 )
 as
 begin
 --exec GetEntitiesByRole 26242
-	if(@LKEntityType2 != 26244)
+	if(@Operation != 3) --3 is farm
 	begin
 		select a.ApplicantId, an.ApplicantName 
 		from Appname an(nolock)
@@ -438,7 +441,8 @@ as
 Begin
 
 	select a.LkAddressType,  a.AddressId, isnull(a.Street#, '') as Street#, isnull(a.Address1, '') as Address1, isnull(a.Address2, '') as Address2, 
-	isnull(a.latitude, '') as latitude, isnull(a.longitude, '') as longitude, isnull(a.Town, '') as Town, isnull(a.State, '') as State, isnull(a.Zip, null) as Zip, 
+	isnull(a.latitude, '') as latitude, isnull(a.longitude, '') as longitude, isnull(a.Town, '') as Town, isnull(a.State, '') as State, 
+	isnull(a.Zip, null) as Zip, 
 	isnull(a.County, '') as County, isnull(Village, '') as Village,
 	a.RowIsActive, pa.DefAddress
 	from ApplicantAddress pa(nolock) 


### PR DESCRIPTION
Lookup values are different in VHCB and VHCBSandbox databases.

 Entity Creation and Update procedures specifically looking for “@LKEntityType2” value for finding the Entity Role “Individual/Organization/Farm”, fixed this issue by not checking the “LKEntityType2” value.

Deployed the script in both the databases.